### PR TITLE
fix unfurl on main recipes page

### DIFF
--- a/.changeset/shy-clocks-explode.md
+++ b/.changeset/shy-clocks-explode.md
@@ -1,0 +1,5 @@
+---
+"gatsby-theme-recipes": patch
+---
+
+fix twitter card image on main recipes page, replace double slashes

--- a/packages/gatsby-theme-recipes/src/components/helmetRecipe.js
+++ b/packages/gatsby-theme-recipes/src/components/helmetRecipe.js
@@ -18,7 +18,10 @@ export default ({ recipe, siteUrl }) => (
     {!!recipe?.featured_image?.fluid?.src ? (
       <meta
         property="og:image"
-        content={`${siteUrl}${recipe.featured_image.fluid.src}`}
+        content={`${siteUrl}${recipe.featured_image.fluid.src.replace(
+          "//",
+          "/"
+        )}`}
       />
     ) : null}
     <meta name="twitter:card" content="summary_large_image" />
@@ -31,7 +34,10 @@ export default ({ recipe, siteUrl }) => (
     {!!recipe?.featured_image?.fluid?.src ? (
       <meta
         name="twitter:image"
-        content={`${siteUrl}${recipe.featured_image.fluid.src}`}
+        content={`${siteUrl}${recipe.featured_image.fluid.src.replace(
+          "//",
+          "/"
+        )}`}
       />
     ) : null}
     <meta name="twitter:label1" content="Total Time" />

--- a/packages/gatsby-theme-recipes/src/components/helmetRecipes.js
+++ b/packages/gatsby-theme-recipes/src/components/helmetRecipes.js
@@ -30,7 +30,7 @@ export default ({ recipes, siteUrl, recipePagePath }) => (
     />
     {!!recipes[0]?.node?.featured_image?.fluid?.src ? (
       <meta
-        property="twitter:image"
+        name="twitter:image"
         content={`${siteUrl}${recipes[0].node.featured_image.fluid.src}`}
       />
     ) : null}

--- a/packages/gatsby-theme-recipes/src/components/helmetRecipes.js
+++ b/packages/gatsby-theme-recipes/src/components/helmetRecipes.js
@@ -18,7 +18,10 @@ export default ({ recipes, siteUrl, recipePagePath }) => (
     {!!recipes[0]?.node?.featured_image?.fluid?.src ? (
       <meta
         property="og:image"
-        content={`${siteUrl}${recipes[0].node.featured_image.fluid.src}`}
+        content={`${siteUrl}${recipes[0].node.featured_image.fluid.src.replace(
+          "//",
+          "/"
+        )}`}
       />
     ) : null}
     <meta name="twitter:card" content="summary_large_image" />
@@ -31,7 +34,10 @@ export default ({ recipes, siteUrl, recipePagePath }) => (
     {!!recipes[0]?.node?.featured_image?.fluid?.src ? (
       <meta
         name="twitter:image"
-        content={`${siteUrl}${recipes[0].node.featured_image.fluid.src}`}
+        content={`${siteUrl}${recipes[0].node.featured_image.fluid.src.replace(
+          "//",
+          "/"
+        )}`}
       />
     ) : null}
   </Helmet>


### PR DESCRIPTION
We missed fixing the twitter image on the main recipes page. Also replace double slash depending on how the user enters the urls.